### PR TITLE
add(http): add query field to http request

### DIFF
--- a/runner_test.go
+++ b/runner_test.go
@@ -258,12 +258,9 @@ func TestRunner_Run_Scenarios(t *testing.T) {
 						if err := d.Decode(&body); err != nil {
 							t.Fatalf("failed to decode request body: %s", err)
 						}
-						var msg string
-						if m, ok := body["message"]; ok {
-							msg = m
-						}
 						b, err := json.Marshal(map[string]string{
-							"message": msg,
+							"message": body["message"],
+							"id":      r.URL.Query().Get("id"),
 						})
 						if err != nil {
 							t.Fatalf("failed to marshal: %s", err)

--- a/testdata/scenarios/http.yaml
+++ b/testdata/scenarios/http.yaml
@@ -3,11 +3,14 @@ title: /echo
 steps:
 - title: POST /echo
   vars:
+    id: "123"
     message: hello
   protocol: http
   request:
     method: POST
     url: "{{env.TEST_ADDR}}/echo"
+    query:
+      id: "{{vars.id}}"
     header:
       Authorization: "Bearer {{env.TEST_TOKEN}}"
     body:
@@ -15,6 +18,7 @@ steps:
   expect:
     code: 200
     body:
+      id: "{{vars.id}}"
       message: "{{request.message}}"
 
 ---


### PR DESCRIPTION
# What

Add query field to http request.
The query field is evaluated and will be merged with url field.

```yaml
  protocol: http
  request:
    method: GET
    url: "http://example.com/hello"
    query:
      id: 123
      message: hey
```

will be equivalent to

```yaml
  protocol: http
  request:
    method: GET
    url: "http://example.com/hello?id=123&message=hey"
```

# Why

Basically, HTTP's GET method is not supposed to have a request body. Therefore some http servers deny GET requests that have a request body. In this case, sending GET requests with senarigo is a little bother. Adding query field makes yaml simpler and more readable.